### PR TITLE
Fix static method error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Donate Link: http://uthsc.edu
 Tags: cas, authentication, central authentication service, phpCAS  
 Requires at least: 3.0.1  
 Tested up to: 4.3.1  
-Stable tag: 1.0  
+Stable tag: 1.0.1  
 License: GPLv3  
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -93,6 +93,9 @@ If you have ideas for features or improvements, let us know or submit a pull req
 
 Changelog
 ---
+1.0.1 -  
+Made method static to resolve error
+
 1.0 -  
 Tested with WordPress version 4.3.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: http://uthsc.edu
 Tags: cas, authentication, central authentication service, phpCAS
 Requires at least: 3.0.1
 Tested up to: 4.3.1
-Stable tag: 1.0
+Stable tag: 1.0.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -84,6 +84,12 @@ If you have ideas for features or improvements, let us know or submit a pull req
 2. Test page in UTHSC-WPCAS settings. The test page provides session info and lists information about the current user. Manual test files are available in the plugin's test directory.
 
 == Changelog ==
+
+= 1.0.1 =
+Made method static to resolve error
+
+= 1.0 =
+Tested with WordPress version 4.3.1
 
 = 0.2.2 =
 Fixed format issue with first name value

--- a/uthsc-wpcas.php
+++ b/uthsc-wpcas.php
@@ -148,7 +148,7 @@ if ( !class_exists('UTHSCWPCAS') ) {
 			}
 		}
 
-		function wpcas_login_url($redirect = '', $force_reauth = false) {
+		static function wpcas_login_url($redirect = '', $force_reauth = false) {
 			$login_url = site_url('wp-login.php', 'login');
 		
 			if ( !empty($redirect) ) {


### PR DESCRIPTION
make method static to resolve wp error
`Strict Standards: call_user_func_array() expects parameter 1 to be a valid callback, non-static method UTHSCWPCAS::wpcas_login_url() should not be called statically in /var/www/laneblogs/docroot/wp-includes/plugin.php on line 235`